### PR TITLE
feat: add GUI context window presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ chat across four supported backends.
 - **Inline images & graphs.** Let an agent run code in your workspace and render the result — images and graphs display inline in the chat panel.
 - **4 backends.** Ollama, llama.cpp, MLX (Apple Silicon), and LM Studio — auto-selected or user-chosen.
 - **AI Hardware Score (0–100).** Diagnose your machine's bottleneck in one command.
-- **Context-window sizing.** KV-cache-aware memory estimates with GQA-correct attention geometry.
+- **Context-window sizing.** Choose Low, Mid, High, or Max in the GUI (25%, 50%, 75%, or 100% of each model's advertised context), backed by KV-cache-aware memory estimates with GQA-correct attention geometry.
 - **Honesty gate.** Unknown figures render as `unknown` — never fabricated.
 - **Integrity-verified installs.** SHA-256 digest checks; fail-closed on mismatch.
 - **Loopback-only.** Servers bind `127.0.0.1` — nothing exposed to the network.
@@ -209,8 +209,22 @@ local-llmup gui --no-open       # start the server without opening a browser
 
 The **Models** view ranks models that fit your hardware with the same
 `yes / slow / no` verdicts and estimated tok/s as the CLI, a per-model **runtime
-picker** for reaching any backend directly, and a **Start** button that brings
-your chosen model online through the verified `up` lifecycle:
+picker** for reaching any backend directly, a **context-window picker**, and a
+**Start** button that brings your chosen model online through the verified `up`
+lifecycle. Context presets re-rank every model at a percentage of its own
+advertised maximum:
+
+| Preset | Model context used | Best for |
+|--------|--------------------|----------|
+| **Low** | 25% | Lower memory use and shorter conversations |
+| **Mid** | 50% | Balanced default |
+| **High** | 75% | Longer documents and conversations |
+| **Max** | 100% | Full advertised model context when hardware allows |
+
+The model cards show the resulting token count. When sourced attention geometry
+is unavailable, the UI reports **context fit unknown** rather than claiming the
+KV cache fits. Throughput ranges remain short-context decode estimates because
+long-context throughput is not modeled yet.
 
 <div align="center">
 <img src="assets/screenshot-gui.png" alt="local-llmup browser workspace \u2014 recommended models" width="800" />

--- a/src/commands/recommend.ts
+++ b/src/commands/recommend.ts
@@ -21,6 +21,7 @@ import { backendsForModel } from "../catalog/backends.js";
 import { createDefaultRegistry, type BackendRegistry } from "../backend/registry.js";
 import { renderJson, renderTable, type Column } from "../output.js";
 import {
+  contextTokensForModel,
   rankModels,
   type RankOptions,
   type RankScores,
@@ -106,6 +107,8 @@ export interface RecommendOptions {
   readonly json?: boolean | undefined;
   /** Size the KV cache at this explicit context (tokens); re-ranks and re-verdicts. */
   readonly context?: number | undefined;
+  /** Size each model at a percentage of its advertised context (GUI presets). */
+  readonly contextPercent?: 25 | 50 | 75 | 100 | undefined;
   /** Report the largest context each model can hold on this hardware. */
   readonly maxContext?: boolean | undefined;
   /** Scope the throughput estimate to this runtime (default `ollama`). */
@@ -215,25 +218,38 @@ export function buildRecommendation(
   registry: BackendRegistry = createDefaultRegistry(),
   availableBackendNames?: readonly string[],
 ): RecommendationResult {
+  const sizingModes = [
+    options.context !== undefined,
+    options.contextPercent !== undefined,
+    options.maxContext === true,
+  ].filter(Boolean).length;
+  if (sizingModes > 1) {
+    throw new ValidationError("context, contextPercent, and maxContext are mutually exclusive");
+  }
   const rankOptions: RankOptions = {
     ...(options.task !== undefined ? { task: options.task } : {}),
     ...(options.context !== undefined ? { context: options.context } : {}),
+    ...(options.contextPercent !== undefined ? { contextPercent: options.contextPercent } : {}),
   };
   const ranking = rankModels(catalog, hardware, rankOptions);
   const usableBytes = usableMemoryBytes(hardware);
   const throughputBackend = options.backend ?? DEFAULT_THROUGHPUT_BACKEND;
 
   let entries: RecommendationEntry[] = ranking.ranked.map((ranked, index) => {
+    const contextTokens =
+      options.contextPercent !== undefined
+        ? contextTokensForModel(ranked.model, options.contextPercent)
+        : options.context;
     const verdict = evaluateVerdict(
       ranked.model,
       hardware,
       perf,
-      options.context,
+      contextTokens,
       throughputBackend,
     );
     const contextSizing =
-      options.context !== undefined
-        ? buildContextSizing(ranked.model, ranked.quant, options.context)
+      contextTokens !== undefined
+        ? buildContextSizing(ranked.model, ranked.quant, contextTokens)
         : undefined;
     const maxContext =
       options.maxContext === true

--- a/src/gui/management.ts
+++ b/src/gui/management.ts
@@ -29,6 +29,9 @@ export interface ManagedModelSummary {
     readonly highTokPerSec: number;
   };
   readonly backends: readonly string[];
+  readonly contextTokens?: number;
+  /** False when attention geometry is unknown and context fit could not be measured. */
+  readonly contextFitKnown?: boolean;
 }
 
 /** A compact, UI-facing view of the active local server. */
@@ -54,6 +57,32 @@ export interface RecommendedOptions {
   readonly limit?: number;
   /** Scope the throughput estimate to this inference runtime (default `ollama`). */
   readonly runtime?: BackendName;
+  /** Model-relative context window used for fit and ranking. */
+  readonly contextPreset?: ContextWindowPreset;
+}
+
+export const CONTEXT_WINDOW_PRESETS = ["low", "mid", "high", "max"] as const;
+export type ContextWindowPreset = (typeof CONTEXT_WINDOW_PRESETS)[number];
+
+const CONTEXT_WINDOW_PERCENT: Readonly<Record<ContextWindowPreset, 25 | 50 | 75 | 100>> = {
+  low: 25,
+  mid: 50,
+  high: 75,
+  max: 100,
+};
+
+const CONTEXT_WINDOW_PRESET_SCHEMA = z.enum(CONTEXT_WINDOW_PRESETS);
+
+/** Parse an optional model-relative context preset from the GUI query string. */
+export function parseContextWindowPreset(raw: string | null): ContextWindowPreset | undefined {
+  if (raw === null || raw.length === 0) return undefined;
+  const parsed = CONTEXT_WINDOW_PRESET_SCHEMA.safeParse(raw);
+  if (!parsed.success) {
+    throw new ValidationError(
+      `unknown context preset: ${raw.slice(0, 40)} (known: ${CONTEXT_WINDOW_PRESETS.join(", ")})`,
+    );
+  }
+  return parsed.data;
 }
 
 /** The management surface the GUI server depends on. */
@@ -117,8 +146,12 @@ export function createModelManager(deps: ModelManagerDeps): GuiModelManager {
   return {
     async recommended(options: RecommendedOptions = {}): Promise<readonly ManagedModelSummary[]> {
       const limit = options.limit ?? DEFAULT_RECOMMEND_LIMIT;
-      const recommendOptions: RecommendOptions =
-        options.runtime !== undefined ? { backend: options.runtime } : {};
+      const recommendOptions: RecommendOptions = {
+        ...(options.runtime !== undefined ? { backend: options.runtime } : {}),
+        ...(options.contextPreset !== undefined
+          ? { contextPercent: CONTEXT_WINDOW_PERCENT[options.contextPreset] }
+          : {}),
+      };
       const result = await deps.collectRecommendation(recommendOptions);
       return result.entries.slice(0, limit).map((entry) => ({
         id: entry.model.id,
@@ -133,6 +166,10 @@ export function createModelManager(deps: ModelManagerDeps): GuiModelManager {
           highTokPerSec: entry.throughput.highTokPerSec,
         },
         backends: [...entry.backends],
+        ...(entry.contextSizing !== undefined ? { contextTokens: entry.contextSizing.tokens } : {}),
+        ...(entry.contextSizing !== undefined
+          ? { contextFitKnown: entry.contextSizing.kvCacheBytes !== null }
+          : {}),
       }));
     },
     runtimes(): readonly BackendName[] {

--- a/src/gui/server.ts
+++ b/src/gui/server.ts
@@ -9,7 +9,11 @@ import { stripControl } from "../sanitize.js";
 import { appendConversation, createSession, type GuiSession } from "./session.js";
 import { MAX_REQUEST_BYTES, parseGuiChatRequest, parseHarnessSwitch, parseRuntimeQuery, readJsonBody, validateHost } from "./handlers.js";
 import { readStaticAsset } from "./static.js";
-import { parseGuiUpRequest, type GuiModelManager } from "./management.js";
+import {
+  parseContextWindowPreset,
+  parseGuiUpRequest,
+  type GuiModelManager,
+} from "./management.js";
 import { toHardwareSummary, type HardwareProvider } from "./hardware.js";
 import type { RuntimeController } from "./runtime.js";
 import type { McpManager } from "../mcp/manager.js";
@@ -203,10 +207,16 @@ export class GuiServer {
       if (req.method === "GET" && pathname === "/api/models/recommended") {
         const manager = this.requireModelManager();
         const runtime = parseRuntimeQuery(url.searchParams.get("runtime"));
-        const models = runtime !== undefined
-          ? await manager.recommended({ runtime })
-          : await manager.recommended();
-        this.writeJson(res, 200, { models, runtime: runtime ?? null });
+        const contextPreset = parseContextWindowPreset(url.searchParams.get("context"));
+        const models = await manager.recommended({
+          ...(runtime !== undefined ? { runtime } : {}),
+          ...(contextPreset !== undefined ? { contextPreset } : {}),
+        });
+        this.writeJson(res, 200, {
+          models,
+          runtime: runtime ?? null,
+          contextPreset: contextPreset ?? null,
+        });
         return;
       }
 

--- a/src/gui/static/chat.js
+++ b/src/gui/static/chat.js
@@ -17,6 +17,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const modelError = document.querySelector("#model-error");
   const activeBanner = document.querySelector("#active-model-banner");
   const refreshModels = document.querySelector("#refresh-models");
+  const contextWindow = document.querySelector("#context-window");
   const sessionCurrent = document.querySelector("#session-current");
   const sessionTurns = document.querySelector("#session-turns");
   const connectorForm = document.querySelector("#connector-form");
@@ -51,6 +52,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const skillCancel = document.querySelector("#skill-cancel");
   const navItems = document.querySelectorAll(".rail-item[data-view]");
   const views = document.querySelectorAll(".view");
+  let modelsRequestSequence = 0;
 
   if (!form || !prompt || !messages) {
     return;
@@ -815,6 +817,10 @@ document.addEventListener("DOMContentLoaded", () => {
     return `${throughput.lowTokPerSec}–${throughput.highTokPerSec} tok/s`;
   }
 
+  function formatTokens(tokens) {
+    return Number.isInteger(tokens) && tokens > 0 ? tokens.toLocaleString() : "unknown";
+  }
+
   function ensureModelOption(id) {
     if (!modelSelect || !id) {
       return;
@@ -941,7 +947,12 @@ document.addEventListener("DOMContentLoaded", () => {
 
       const meta = document.createElement("div");
       meta.className = "model-card-meta";
-      meta.textContent = `${model.params} · ${model.quant} · ${formatSize(model.diskBytes)} · ${formatThroughput(model.throughput)}`;
+      const context = model.contextTokens
+        ? model.contextFitKnown === false
+          ? ` · ${formatTokens(model.contextTokens)} context tokens · context fit unknown`
+          : ` · ${formatTokens(model.contextTokens)} context tokens`
+        : "";
+      meta.textContent = `${model.params} · ${model.quant} · ${formatSize(model.diskBytes)} · ${formatThroughput(model.throughput)}${context}`;
 
       const actions = document.createElement("div");
       actions.className = "model-card-actions";
@@ -983,39 +994,65 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   }
 
-  async function loadActive() {
+  async function loadActive(render = true) {
     try {
       const response = await globalThis.fetch("/api/models/active");
       if (!response.ok) {
-        return null;
+        return undefined;
       }
       const data = await response.json();
-      renderActive(data.active);
+      if (render) {
+        renderActive(data.active);
+      }
       return data.active;
     } catch {
-      return null;
+      return undefined;
     }
   }
 
   async function loadModels() {
+    const requestSequence = ++modelsRequestSequence;
     if (modelError) {
       modelError.hidden = true;
     }
-    const active = await loadActive();
+    const active = await loadActive(false);
+    if (requestSequence !== modelsRequestSequence) {
+      return;
+    }
+    if (active === undefined) {
+      if (modelError) {
+        modelError.hidden = false;
+        modelError.textContent = "Could not load active model status.";
+      }
+      return;
+    }
+    renderActive(active);
     if (!recommendedList) {
       return;
     }
     try {
       const runtime = selectedRuntime();
-      const query = runtime ? `?runtime=${encodeURIComponent(runtime)}` : "";
-      const response = await globalThis.fetch(`/api/models/recommended${query}`);
+      const params = new globalThis.URLSearchParams();
+      if (runtime) {
+        params.set("runtime", runtime);
+      }
+      if (contextWindow && contextWindow.value) {
+        params.set("context", contextWindow.value);
+      }
+      const response = await globalThis.fetch(`/api/models/recommended?${params.toString()}`);
       if (!response.ok) {
         throw new Error(`request failed (${response.status})`);
       }
       const data = await response.json();
+      if (requestSequence !== modelsRequestSequence) {
+        return;
+      }
       const models = Array.isArray(data.models) ? data.models : [];
       renderRecommended(models, active);
     } catch (error) {
+      if (requestSequence !== modelsRequestSequence) {
+        return;
+      }
       recommendedList.innerHTML = "";
       const empty = document.createElement("div");
       empty.className = "recommended-empty";
@@ -1026,6 +1063,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
   if (refreshModels) {
     refreshModels.addEventListener("click", () => loadModels());
+  }
+
+  if (contextWindow) {
+    contextWindow.addEventListener("change", () => loadModels());
   }
 
   if (refreshRuntime) {

--- a/src/gui/static/index.html
+++ b/src/gui/static/index.html
@@ -129,8 +129,20 @@
                 <p class="section-sub">
                   Recommendations are scored against your hardware for the selected runtime. Pick one to serve it locally.
                 </p>
+                <p class="section-note">Throughput ranges are short-context decode estimates.</p>
               </div>
-              <button id="refresh-models" class="ghost-btn" type="button">Refresh</button>
+              <div class="model-toolbar">
+                <label class="context-control" for="context-window">
+                  <span>Context window</span>
+                  <select id="context-window">
+                    <option value="low">Low · 25%</option>
+                    <option value="mid" selected>Mid · 50%</option>
+                    <option value="high">High · 75%</option>
+                    <option value="max">Max · 100%</option>
+                  </select>
+                </label>
+                <button id="refresh-models" class="ghost-btn" type="button">Refresh</button>
+              </div>
             </div>
 
             <div id="active-model-banner" class="banner" hidden></div>

--- a/src/gui/static/styles.css
+++ b/src/gui/static/styles.css
@@ -734,6 +734,41 @@ input {
   max-width: 52ch;
 }
 
+.section-note {
+  margin: 0.35rem 0 0;
+  color: var(--muted);
+  font-size: 0.74rem;
+}
+
+.model-toolbar {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.6rem;
+}
+
+.context-control {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.context-control span {
+  color: var(--muted);
+  font-size: 0.66rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.context-control select {
+  min-width: 9rem;
+  padding: 0.5rem 0.65rem;
+  border: 1px solid var(--stroke-strong);
+  border-radius: 10px;
+  background: var(--glass-strong);
+  color: var(--text);
+  font-weight: 600;
+  cursor: pointer;
+}
+
 /* Banners */
 .banner {
   padding: 0.7rem 0.9rem;
@@ -1256,6 +1291,20 @@ input {
   }
   .pills {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .section-head,
+  .model-toolbar {
+    flex-wrap: wrap;
+  }
+  .model-toolbar {
+    width: 100%;
+  }
+  .context-control {
+    flex: 1 1 10rem;
+  }
+  .context-control select {
+    width: 100%;
+    min-width: 0;
   }
 }
 

--- a/src/ranking/rank.ts
+++ b/src/ranking/rank.ts
@@ -62,6 +62,16 @@ export interface RankOptions {
    * `context-bound`. Omitted → the calibrated default footprint.
    */
   readonly context?: number | undefined;
+  /** Evaluate each model at this percentage of its advertised context length. */
+  readonly contextPercent?: 25 | 50 | 75 | 100 | undefined;
+}
+
+/** Resolve a model-relative context percentage to an integer token count. */
+export function contextTokensForModel(
+  model: CatalogModel,
+  percent: 25 | 50 | 75 | 100,
+): number {
+  return Math.max(1, Math.floor((model.contextLength * percent) / 100));
 }
 
 const MS_PER_DAY = 86_400_000;
@@ -176,9 +186,13 @@ export function rankModels(
   const wontFit: WontFitModel[] = [];
 
   for (const model of catalog.models) {
+    const contextTokens =
+      options.contextPercent !== undefined
+        ? contextTokensForModel(model, options.contextPercent)
+        : options.context;
     const fit =
-      options.context !== undefined
-        ? evaluateFitAtContext(model, hw, options.context)
+      contextTokens !== undefined
+        ? evaluateFitAtContext(model, hw, contextTokens)
         : evaluateFit(model, hw);
     if (!fit.fits) {
       wontFit.push({ model, reason: fit.reason });

--- a/tests/commands/recommend.test.ts
+++ b/tests/commands/recommend.test.ts
@@ -523,6 +523,23 @@ function known(id: string, diskBytes: number, kv: number, contextLength = 131072
 }
 
 describe("buildRecommendation --context", () => {
+  it("sizes each model at the requested percentage of its advertised context", () => {
+    const cat = catalog([
+      known("small-context:8b", 4_900_000_000, 1024, 8192),
+      known("large-context:8b", 4_900_000_000, 1024, 131072),
+    ]);
+    const result = build(cat, appleHw(64), { contextPercent: 25 });
+
+    expect(
+      Object.fromEntries(
+        result.entries.map((entry) => [entry.model.id, entry.contextSizing?.tokens]),
+      ),
+    ).toEqual({
+      "small-context:8b": 2048,
+      "large-context:8b": 32768,
+    });
+  });
+
   it("sizes each entry's weights and KV cache at the requested context", () => {
     const cat = catalog([known("llama3.1:8b", 4_900_000_000, LLAMA_KV)]);
     const result = build(cat, appleHw(64), { context: 8192 });
@@ -531,6 +548,16 @@ describe("buildRecommendation --context", () => {
     expect(entry.contextSizing!.tokens).toBe(8192);
     expect(entry.contextSizing!.weightsBytes).toBeGreaterThan(0);
     expect(entry.contextSizing!.kvCacheBytes).toBe(LLAMA_KV * 8192);
+  });
+
+  it("rejects conflicting context sizing modes", () => {
+    const cat = catalog([known("llama3.1:8b", 4_900_000_000, LLAMA_KV)]);
+    expect(() => build(cat, appleHw(64), { context: 8192, contextPercent: 50 })).toThrow(
+      ValidationError,
+    );
+    expect(() => build(cat, appleHw(64), { contextPercent: 50, maxContext: true })).toThrow(
+      ValidationError,
+    );
   });
 
   it("moves a model that fits at a small context but not a large one to won't-fit with a memory reason (CW4)", () => {

--- a/tests/gui/management.test.ts
+++ b/tests/gui/management.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { ValidationError } from "../../src/errors.js";
-import { createModelManager, parseGuiUpRequest } from "../../src/gui/management.js";
+import {
+  createModelManager,
+  parseContextWindowPreset,
+  parseGuiUpRequest,
+} from "../../src/gui/management.js";
 import type { RecommendationResult } from "../../src/commands/recommend.js";
 import type { LsResult } from "../../src/commands/ls.js";
 
@@ -89,6 +93,22 @@ describe("parseGuiUpRequest", () => {
   });
 });
 
+describe("parseContextWindowPreset", () => {
+  it("accepts the four context-window presets and an absent value", () => {
+    expect(["low", "mid", "high", "max"].map(parseContextWindowPreset)).toEqual([
+      "low",
+      "mid",
+      "high",
+      "max",
+    ]);
+    expect(parseContextWindowPreset(null)).toBeUndefined();
+  });
+
+  it("rejects unknown context-window presets", () => {
+    expect(() => parseContextWindowPreset("extreme")).toThrow(ValidationError);
+  });
+});
+
 describe("createModelManager", () => {
   it("maps recommendation entries to compact summaries", async () => {
     const manager = createModelManager({
@@ -144,6 +164,45 @@ describe("createModelManager", () => {
     expect(seen[1]).toEqual({});
 
     expect(manager.runtimes()).toEqual(["ollama", "llamacpp", "mlx", "lmstudio"]);
+  });
+
+  it.each([
+    ["low", 25],
+    ["mid", 50],
+    ["high", 75],
+    ["max", 100],
+  ] as const)("maps the %s GUI preset to %i%% model-relative sizing", async (contextPreset, contextPercent) => {
+    const collectRecommendation = vi.fn(async () => makeRecommendation());
+    const manager = createModelManager({
+      collectRecommendation,
+      runUp: async () => undefined,
+      collectLs: () => ({ type: "empty" }),
+    });
+
+    await manager.recommended({ runtime: "ollama", contextPreset });
+
+    expect(collectRecommendation).toHaveBeenCalledWith({ backend: "ollama", contextPercent });
+  });
+
+  it("preserves an unknown context-fit result for honest UI rendering", async () => {
+    const recommendation = makeRecommendation();
+    const manager = createModelManager({
+      collectRecommendation: async () => ({
+        ...recommendation,
+        entries: [
+          {
+            ...recommendation.entries[0]!,
+            contextSizing: { tokens: 4096, weightsBytes: 1_000_000, kvCacheBytes: null },
+          },
+        ],
+      }),
+      runUp: async () => undefined,
+      collectLs: () => ({ type: "empty" }),
+    });
+
+    await expect(manager.recommended({ contextPreset: "low" })).resolves.toMatchObject([
+      { contextTokens: 4096, contextFitKnown: false },
+    ]);
   });
 
   it("returns the active model summary or null", () => {

--- a/tests/gui/server.test.ts
+++ b/tests/gui/server.test.ts
@@ -275,6 +275,38 @@ describe("GuiServer", () => {
     expect(badBody.error).toContain("unknown runtime");
   });
 
+  it("forwards a validated context-window preset to recommendations", async () => {
+    const seen: (string | undefined)[] = [];
+    const server = new GuiServer({
+      rootDir: new URL("../../src/gui/static", import.meta.url),
+      registry: undefined,
+      modelManager: {
+        recommended: async (options) => {
+          seen.push(options?.contextPreset);
+          return [];
+        },
+        runtimes: () => ["ollama", "llamacpp", "mlx", "lmstudio"],
+        active: () => null,
+        up: async () => {
+          throw new Error("not used");
+        },
+      },
+    });
+    servers.push(server);
+
+    const port = await server.start(0);
+    const ok = await fetch(`http://127.0.0.1:${port}/api/models/recommended?context=high`, {
+      headers: { Host: `127.0.0.1:${port}` },
+    });
+    expect(ok.status).toBe(200);
+    expect(seen).toEqual(["high"]);
+
+    const bad = await fetch(`http://127.0.0.1:${port}/api/models/recommended?context=extreme`, {
+      headers: { Host: `127.0.0.1:${port}` },
+    });
+    expect(bad.status).toBe(400);
+  });
+
   it("reports the active workspace model", async () => {
     const server = new GuiServer({
       rootDir: new URL("../../src/gui/static", import.meta.url),


### PR DESCRIPTION
## Summary
- add Low, Mid, High, and Max context-window choices to the Models UI
- map presets to 25%, 50%, 75%, and 100% of each model's advertised context and re-rank recommendations
- show selected token counts, preserve unknown-fit honesty, and disclose short-context throughput assumptions
- validate GUI query input, ignore stale responses, and support narrow-screen reflow
- document the feature in the README

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- focused GUI/context tests: 78 passed
- real-browser verification at desktop and 320px widths

## Known unrelated test failures
- full suite: 1658 passed, 3 failed in `tests/backend/ollama-lifecycle.test.ts`
- failures are existing child-process cleanup/PID mock assertions and are unrelated to this change
