### PR TITLE
fix: prefer higher-precision fitting quant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Model Selection
+
+- Prefer a recognized higher-precision quantization when multiple fitting
+  variants have the same measured memory footprint. Unknown quantization
+  formats remain ordered by measured size without fabricated quality estimates.
+
 ## 0.11.2 - 2026-09-01
 
 **Broader model coverage with an auditable catalog pipeline.**

--- a/src/ranking/fit.ts
+++ b/src/ranking/fit.ts
@@ -5,6 +5,7 @@
  * it is excluded with a typed reason so the caller can explain *why*.
  */
 import {
+  quantBitsPerParam,
   requiredMemoryAtContext,
   requiredMemoryBytes,
   usableMemoryBytes,
@@ -114,8 +115,17 @@ function evaluateFitWith(
       // count → higher bits-per-param, and catalog `diskBytes` is non-decreasing
       // with quality; at a fixed context the KV term is quant-independent), so
       // the largest fitting `requiredBytes` is the highest-quality fitting quant.
-      // Ties keep the first quant encountered.
-      if (best === undefined || requiredBytes > best.requiredBytes) {
+      // Equal measured footprints are possible after registry enrichment. In
+      // that case prefer explicitly recognized higher precision; unknown
+      // formats keep catalog order rather than receiving a guessed quality.
+      const quantBits = quantBitsPerParam(quant.name);
+      const bestBits = best === undefined ? undefined : quantBitsPerParam(best.quant.name);
+      const hasHigherKnownPrecision =
+        requiredBytes === best?.requiredBytes &&
+        quantBits !== undefined &&
+        bestBits !== undefined &&
+        quantBits > bestBits;
+      if (best === undefined || requiredBytes > best.requiredBytes || hasHigherKnownPrecision) {
         best = { fits: true, quant, requiredBytes, usableBytes };
       }
     }

--- a/tests/ranking/fit.test.ts
+++ b/tests/ranking/fit.test.ts
@@ -72,6 +72,31 @@ describe("evaluateFit", () => {
     if (result.fits) expect(result.quant.name).toBe("Q4_K_M");
   });
 
+  it("prefers recognized higher precision when fitting quants have equal footprints", () => {
+    const equalFootprintQ4 = { ...Q4, diskBytes: 20 * GIB, minVramBytes: 20 * GIB };
+    const equalFootprintQ8 = {
+      ...Q8,
+      diskBytes: equalFootprintQ4.diskBytes,
+      minVramBytes: equalFootprintQ4.minVramBytes,
+    };
+    const result = evaluateFit(
+      model({ quantizations: [equalFootprintQ4, equalFootprintQ8] }),
+      gpuHw(32 * GIB),
+    );
+
+    expect(result.fits).toBe(true);
+    if (result.fits) expect(result.quant.name).toBe("Q8_0");
+  });
+
+  it("uses measured footprint to order unknown quantization formats", () => {
+    const compact = { ...Q4, name: "custom-small" };
+    const larger = { ...Q8, name: "custom-large" };
+    const result = evaluateFit(model({ quantizations: [compact, larger] }), gpuHw(16 * GIB));
+
+    expect(result.fits).toBe(true);
+    if (result.fits) expect(result.quant.name).toBe("custom-large");
+  });
+
   it("excludes kimi-k2 as ram-bound on consumer hardware", () => {
     const kimi = model({
       id: "kimi-k2:instruct",


### PR DESCRIPTION
## Summary
- Recognized bits-per-parameter breaks equal measured-footprint ties.
- Measured footprint remains primary.
- Unknown formats retain catalog order; no guessed quality.

## Rationale
References #233 and the honesty gate: prefer a higher-precision fitting quant when measured footprints tie without inventing quality for unknown formats.

## Tests
- Focused: 15
- Full: 1,853
- Lint/typecheck/build

Addresses #233 (not closing it).

This PR is intentionally stacked after PR 2.
