### PR TITLE
feat: declare embedding offload capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Backend Capabilities
+
+- Added an explicit `supported | unsupported | unknown` embedding-layer offload
+  capability to backend adapters. Current backends report `unknown` until
+  runtime support can be observed without inference.
+
 ### Model Selection
 
 - Prefer a recognized higher-precision quantization when multiple fitting

--- a/src/backend/llamacpp.ts
+++ b/src/backend/llamacpp.ts
@@ -381,6 +381,7 @@ export class LlamaCppAdapter implements BackendAdapter {
     // `false`: memory capture then degrades to the vector-less path (honest, no
     // fabricated vectors) rather than calling an endpoint that isn't enabled.
     canEmbed: false,
+    embeddingOffload: "unknown",
     openAiCompatible: true,
     formats: ["gguf"],
     defaultPort: LLAMACPP_DEFAULT_PORT,

--- a/src/backend/lmstudio.ts
+++ b/src/backend/lmstudio.ts
@@ -288,6 +288,7 @@ export class LmStudioAdapter implements BackendAdapter {
   readonly capabilities: BackendCapabilities = {
     canPull: false,
     canEmbed: true,
+    embeddingOffload: "unknown",
     openAiCompatible: true,
     formats: ["gguf", "mlx"],
     defaultPort: LM_STUDIO_DEFAULT_PORT,

--- a/src/backend/mlx.ts
+++ b/src/backend/mlx.ts
@@ -297,6 +297,7 @@ export class MlxAdapter implements BackendAdapter {
   readonly capabilities: BackendCapabilities = {
     canPull: true,
     canEmbed: false,
+    embeddingOffload: "unknown",
     openAiCompatible: true,
     formats: ["mlx"],
     defaultPort: MLX_DEFAULT_PORT,

--- a/src/backend/ollama.ts
+++ b/src/backend/ollama.ts
@@ -631,6 +631,7 @@ export class OllamaAdapter implements BackendAdapter {
   readonly capabilities: BackendCapabilities = {
     canPull: true,
     canEmbed: true,
+    embeddingOffload: "unknown",
     openAiCompatible: true,
     formats: ["ollama"],
     defaultPort: DEFAULT_OLLAMA_PORT,

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,10 @@ export type ModelFormat = (typeof MODEL_FORMATS)[number];
 export const BACKEND_NAMES = ["ollama", "llamacpp", "mlx", "lmstudio"] as const;
 export type BackendName = (typeof BACKEND_NAMES)[number];
 
+/** Runtime-observed support state for backend-specific inference features. */
+export const BACKEND_SUPPORT_STATES = ["supported", "unsupported", "unknown"] as const;
+export type BackendSupportState = (typeof BACKEND_SUPPORT_STATES)[number];
+
 /**
  * Declarative capability descriptor a backend advertises so command code
  * branches on data rather than per-call feature detection.
@@ -52,6 +56,8 @@ export interface BackendCapabilities {
   readonly canPull: boolean;
   /** False → embeddings must use a different backend. */
   readonly canEmbed: boolean;
+  /** Whether embedding layers can leave primary compute memory; omission means unknown. */
+  readonly embeddingOffload?: BackendSupportState;
   readonly openAiCompatible: boolean;
   /** Weight formats this backend can serve. */
   readonly formats: readonly ModelFormat[];

--- a/tests/backend/adapter.test.ts
+++ b/tests/backend/adapter.test.ts
@@ -14,7 +14,12 @@ import {
   type ServeOptions,
 } from "../../src/backend/adapter.js";
 import { OllamaAdapter } from "../../src/backend/ollama.js";
-import { MODEL_FORMATS, type BackendCapabilities, type ModelFormat } from "../../src/types.js";
+import {
+  BACKEND_SUPPORT_STATES,
+  MODEL_FORMATS,
+  type BackendCapabilities,
+  type ModelFormat,
+} from "../../src/types.js";
 
 describe("endpoint helpers", () => {
   it("defaults to loopback and the Ollama port", () => {
@@ -59,6 +64,7 @@ class FakeAdapter implements BackendAdapter {
   readonly capabilities: BackendCapabilities = {
     canPull: true,
     canEmbed: true,
+    embeddingOffload: "unknown",
     openAiCompatible: true,
     formats: ["ollama"],
     defaultPort: DEFAULT_OLLAMA_PORT,
@@ -142,10 +148,15 @@ describe("BackendCapabilities", () => {
     expect(MODEL_FORMATS).toEqual(["gguf", "mlx", "ollama", "safetensors"]);
   });
 
+  it("enumerates runtime-observed support without collapsing unknown to false", () => {
+    expect(BACKEND_SUPPORT_STATES).toEqual(["supported", "unsupported", "unknown"]);
+  });
+
   it("types a descriptor an adapter can expose", () => {
     const caps: BackendCapabilities = {
       canPull: true,
       canEmbed: false,
+      embeddingOffload: "unknown",
       openAiCompatible: true,
       formats: ["gguf"],
       defaultPort: 8080,
@@ -161,6 +172,7 @@ describe("OllamaAdapter capabilities descriptor", () => {
     expect(adapter.capabilities).toEqual({
       canPull: true,
       canEmbed: true,
+      embeddingOffload: "unknown",
       openAiCompatible: true,
       formats: ["ollama"],
       defaultPort: DEFAULT_OLLAMA_PORT,

--- a/tests/backend/llamacpp.test.ts
+++ b/tests/backend/llamacpp.test.ts
@@ -77,6 +77,7 @@ describe("LlamaCppAdapter — capabilities", () => {
     expect(adapter.capabilities).toEqual({
       canPull: true,
       canEmbed: false,
+      embeddingOffload: "unknown",
       openAiCompatible: true,
       formats: ["gguf"],
       defaultPort: 8080,

--- a/tests/backend/lmstudio.test.ts
+++ b/tests/backend/lmstudio.test.ts
@@ -63,6 +63,7 @@ describe("LmStudioAdapter — descriptor and installation", () => {
     expect(adapter.capabilities).toEqual({
       canPull: false,
       canEmbed: true,
+      embeddingOffload: "unknown",
       openAiCompatible: true,
       formats: ["gguf", "mlx"],
       defaultPort: 1234,

--- a/tests/backend/mlx.test.ts
+++ b/tests/backend/mlx.test.ts
@@ -50,6 +50,7 @@ describe("MlxAdapter — descriptor and installation", () => {
     expect(adapter.capabilities).toEqual({
       canPull: true,
       canEmbed: false,
+      embeddingOffload: "unknown",
       openAiCompatible: true,
       formats: ["mlx"],
       defaultPort: 8080,

--- a/tests/backend/registry.test.ts
+++ b/tests/backend/registry.test.ts
@@ -28,6 +28,7 @@ function fakeAdapter(options: FakeAdapterOptions): BackendAdapter {
     capabilities: {
       canPull: true,
       canEmbed: true,
+      embeddingOffload: "unknown",
       openAiCompatible: true,
       formats: ["ollama"],
       defaultPort: 11434,

--- a/tests/backend/select.test.ts
+++ b/tests/backend/select.test.ts
@@ -29,6 +29,7 @@ function fakeAdapter(options: FakeAdapterOptions): BackendAdapter {
     capabilities: {
       canPull: true,
       canEmbed: true,
+      embeddingOffload: "unknown",
       openAiCompatible: true,
       formats: ["ollama"],
       defaultPort: 11434,

--- a/tests/catalog/backends.test.ts
+++ b/tests/catalog/backends.test.ts
@@ -25,6 +25,7 @@ function fakeAdapter(
     capabilities: {
       canPull: true,
       canEmbed: true,
+      embeddingOffload: "unknown",
       openAiCompatible: true,
       formats,
       defaultPort: 8080,

--- a/tests/commands/chat.test.ts
+++ b/tests/commands/chat.test.ts
@@ -60,6 +60,7 @@ const baseAdapter: BackendAdapter = {
   capabilities: {
     canPull: true,
     canEmbed: true,
+    embeddingOffload: "unknown",
     openAiCompatible: true,
     formats: ["ollama"],
     defaultPort: 11434,

--- a/tests/commands/doctor.test.ts
+++ b/tests/commands/doctor.test.ts
@@ -72,6 +72,7 @@ function fakeAdapter(overrides: Partial<BackendAdapter> = {}): BackendAdapter {
     capabilities: {
       canPull: true,
       canEmbed: true,
+      embeddingOffload: "unknown",
       openAiCompatible: true,
       formats: ["ollama"],
       defaultPort: 11434,

--- a/tests/commands/down.test.ts
+++ b/tests/commands/down.test.ts
@@ -64,6 +64,7 @@ function fakeAdapter(): FakeAdapter {
     capabilities: {
       canPull: true,
       canEmbed: true,
+      embeddingOffload: "unknown",
       openAiCompatible: true,
       formats: ["ollama"],
       defaultPort: 11434,

--- a/tests/commands/migrate.test.ts
+++ b/tests/commands/migrate.test.ts
@@ -112,6 +112,7 @@ function fakeAdapter(chat?: (req: ChatRequest) => Promise<ChatResult>): BackendA
     capabilities: {
       canPull: true,
       canEmbed: true,
+      embeddingOffload: "unknown",
       openAiCompatible: true,
       formats: ["ollama"],
       defaultPort: 11434,

--- a/tests/commands/recommend.test.ts
+++ b/tests/commands/recommend.test.ts
@@ -29,6 +29,7 @@ function fakeAdapter(overrides: Partial<BackendAdapter> = {}): BackendAdapter {
     capabilities: {
       canPull: true,
       canEmbed: true,
+      embeddingOffload: "unknown",
       openAiCompatible: true,
       formats: ["ollama"],
       defaultPort: 11434,
@@ -342,6 +343,7 @@ describe("backend surfacing (B12)", () => {
       capabilities: {
         canPull: true,
         canEmbed: false,
+        embeddingOffload: "unknown",
         openAiCompatible: true,
         formats: ["mlx"],
         defaultPort: 8080,

--- a/tests/commands/switch.test.ts
+++ b/tests/commands/switch.test.ts
@@ -82,6 +82,7 @@ function fakeAdapter(
     capabilities: {
       canPull: options.canPull ?? true,
       canEmbed: true,
+      embeddingOffload: "unknown",
       openAiCompatible: true,
       formats: options.formats ?? ["ollama"],
       defaultPort: 11434,

--- a/tests/commands/up.test.ts
+++ b/tests/commands/up.test.ts
@@ -186,6 +186,7 @@ function fakeAdapter(options: FakeAdapterOptions = {}): FakeAdapter {
     capabilities: {
       canPull: options.canPull ?? true,
       canEmbed: backendName !== "llamacpp" && backendName !== "mlx",
+      embeddingOffload: "unknown",
       openAiCompatible: true,
       formats: [...formats],
       defaultPort,

--- a/tests/gui/runtime.test.ts
+++ b/tests/gui/runtime.test.ts
@@ -28,6 +28,7 @@ function fakeAdapter(
     capabilities: {
       canPull: name === "ollama",
       canEmbed: false,
+      embeddingOffload: "unknown",
       openAiCompatible: true,
       formats: [],
       defaultPort: port,

--- a/tests/harness/local.test.ts
+++ b/tests/harness/local.test.ts
@@ -29,6 +29,7 @@ describe("createLocalHarness", () => {
       capabilities: {
         canPull: true,
         canEmbed: true,
+        embeddingOffload: "unknown",
         openAiCompatible: true,
         formats: ["ollama"],
         defaultPort: 11434,
@@ -84,6 +85,7 @@ describe("createLocalHarness", () => {
       capabilities: {
         canPull: true,
         canEmbed: true,
+        embeddingOffload: "unknown",
         openAiCompatible: true,
         formats: ["ollama"],
         defaultPort: 11434,
@@ -145,6 +147,7 @@ describe("createLocalHarness", () => {
       capabilities: {
         canPull: false,
         canEmbed: false,
+        embeddingOffload: "unknown",
         openAiCompatible: true,
         formats: ["gguf"],
         defaultPort: 1234,

--- a/tests/tui/chat-entry.test.ts
+++ b/tests/tui/chat-entry.test.ts
@@ -75,6 +75,7 @@ function chatAdapter(replies: readonly string[]): {
     capabilities: {
       canPull: true,
       canEmbed: true,
+      embeddingOffload: "unknown",
       openAiCompatible: true,
       formats: ["ollama"],
       defaultPort: 11434,


### PR DESCRIPTION
## Summary

- add a tri-state `supported | unsupported | unknown` backend capability for embedding-layer offload
- keep the public adapter contract backward compatible: omission means `unknown`
- make Ollama, llama.cpp, MLX, and LM Studio report `unknown` until runtime support is observed
- update adapter fixtures and document the capability groundwork

## Rationale

Issue #232 requires backend-specific evidence before advisor estimates or UI claims are safe. This establishes the capability boundary without inferring support from model family, hardware, or backend name.

## Validation

- 133 test files, 1,883 tests passed
- focused capability and affected suites: 17 files, 390 tests passed
- ESLint passed
- TypeScript typecheck passed
- build passed

Addresses #232. Runtime-specific detection and actual placement controls remain follow-up work.